### PR TITLE
Rebranding packaging to symbol in Java examples 

### DIFF
--- a/source/resources/examples/java/build.gradle
+++ b/source/resources/examples/java/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 apply plugin: 'java'
 group 'io.nem'
-version '0.17.0'
+version '0.17.0-SNAPSHOT'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -30,8 +30,7 @@ ext {
 
 dependencies {
 
-    compile "io.nem:sdk-vertx-client:${project.version}"
-    implementation 'com.google.code.gson:gson:2.8.6'
+    compile "io.nem:symbol-sdk-vertx-client:${project.version}"
 
     // Tests
     testCompile 'org.slf4j:slf4j-simple:1.7.25'

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/account/CreatingAnAccount.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/account/CreatingAnAccount.java
@@ -18,8 +18,8 @@
 
 package symbol.guides.examples.account;
 
-import io.nem.sdk.model.account.Account;
-import io.nem.sdk.model.blockchain.NetworkType;
+import io.nem.symbol.sdk.model.account.Account;
+import io.nem.symbol.sdk.model.blockchain.NetworkType;
 import org.junit.jupiter.api.Test;
 
 class CreatingAnAccount {

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/account/GettingAccountInformation.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/account/GettingAccountInformation.java
@@ -18,18 +18,16 @@
 
 package symbol.guides.examples.account;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.AccountRepository;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.AccountInfo;
-import io.nem.sdk.model.account.Address;
-
-import java.io.StringWriter;
-import java.util.concurrent.ExecutionException;
+import io.nem.symbol.sdk.api.AccountRepository;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.JsonHelperJackson2;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.account.AccountInfo;
+import io.nem.symbol.sdk.model.account.Address;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
 
 class GettingAccountInformation {
 
@@ -49,8 +47,8 @@ class GettingAccountInformation {
             final Address address = Address.createFromRawAddress(rawAddress);
             final AccountInfo accountInfo = accountRepository
                 .getAccountInfo(address).toFuture().get();
-            final Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            System.out.println(gson.toJson(accountInfo));
+            final JsonHelper helper = new JsonHelperJackson2();
+            System.out.println(helper.prettyPrint(accountInfo));
         }
         /* end block 01 */
     }

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/account/GettingConfirmedTransactions.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/account/GettingConfirmedTransactions.java
@@ -18,15 +18,15 @@
 
 package symbol.guides.examples.account;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.AccountRepository;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.api.TransactionSearchCriteria;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.PublicAccount;
-import io.nem.sdk.model.blockchain.NetworkType;
-import io.nem.sdk.model.transaction.Transaction;
+import io.nem.symbol.sdk.api.AccountRepository;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.api.TransactionSearchCriteria;
+import io.nem.symbol.sdk.infrastructure.vertx.JsonHelperJackson2;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.account.PublicAccount;
+import io.nem.symbol.sdk.model.blockchain.NetworkType;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
+import io.nem.symbol.sdk.model.transaction.Transaction;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -58,8 +58,8 @@ class GettingConfirmedTransactions {
 
             final List<Transaction> transactions = accountRepository
                     .transactions(publicAccount, transactionSearchCriteria).toFuture().get();
-            final Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            System.out.println(gson.toJson(transactions));
+            final JsonHelper helper = new JsonHelperJackson2();
+            System.out.println(helper.prettyPrint(transactions));
         }
         /* end block 01 */
     }

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/account/OpeningAnAccount.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/account/OpeningAnAccount.java
@@ -18,8 +18,8 @@
 
 package symbol.guides.examples.account;
 
-import io.nem.sdk.model.account.Account;
-import io.nem.sdk.model.blockchain.NetworkType;
+import io.nem.symbol.sdk.model.account.Account;
+import io.nem.symbol.sdk.model.blockchain.NetworkType;
 import org.junit.jupiter.api.Test;
 
 class OpeningAnAccount {

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/blockchain/GettingBlockByHeight.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/blockchain/GettingBlockByHeight.java
@@ -18,12 +18,12 @@
 
 package symbol.guides.examples.blockchain;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.BlockRepository;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.blockchain.BlockInfo;
+import io.nem.symbol.sdk.api.BlockRepository;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.JsonHelperJackson2;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.blockchain.BlockInfo;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
@@ -45,8 +45,8 @@ class GettingBlockByHeight {
             final BigInteger blockHeight = BigInteger.valueOf(1);
             final BlockInfo blockInfo = blockRepository.getBlockByHeight(blockHeight).toFuture()
                 .get();
-            final Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            System.out.println(gson.toJson(blockInfo));
+            final JsonHelper helper = new JsonHelperJackson2();
+            System.out.println(helper.prettyPrint(blockInfo));
         }
         /* end block 01 */
     }

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/blockchain/GettingBlockchainHeight.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/blockchain/GettingBlockchainHeight.java
@@ -18,9 +18,9 @@
 
 package symbol.guides.examples.blockchain;
 
-import io.nem.sdk.api.ChainRepository;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.api.ChainRepository;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
 import java.math.BigInteger;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/blockchain/GettingTheCurrentMosaicIdentifierBehindANamespace.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/blockchain/GettingTheCurrentMosaicIdentifierBehindANamespace.java
@@ -18,11 +18,11 @@
 
 package symbol.guides.examples.blockchain;
 
-import io.nem.sdk.api.NamespaceRepository;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.mosaic.MosaicId;
-import io.nem.sdk.model.namespace.NamespaceId;
+import io.nem.symbol.sdk.api.NamespaceRepository;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.namespace.NamespaceId;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/blockchain/ListeningNewBlocks.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/blockchain/ListeningNewBlocks.java
@@ -18,11 +18,6 @@
 
 package symbol.guides.examples.blockchain;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.Listener;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/metadata/GettingMetadataEntriesAccount.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/metadata/GettingMetadataEntriesAccount.java
@@ -18,13 +18,13 @@
 
 package symbol.guides.examples.metadata;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.MetadataRepository;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.Address;
-import io.nem.sdk.model.metadata.Metadata;
+import io.nem.symbol.sdk.api.MetadataRepository;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.JsonHelperJackson2;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.account.Address;
+import io.nem.symbol.sdk.model.metadata.Metadata;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -48,8 +48,8 @@ class GettingMetadataEntriesAccount {
 
             final List<Metadata> metadata = metadataRepository.getAccountMetadata(address, Optional.empty())
                     .toFuture().get();
-            final Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            System.out.println(gson.toJson(metadata));
+            final JsonHelper helper = new JsonHelperJackson2();
+            System.out.println(helper.prettyPrint(metadata));
         }
         /* end block 01 */
     }

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/metadata/GettingMetadataEntriesMosaic.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/metadata/GettingMetadataEntriesMosaic.java
@@ -18,14 +18,13 @@
 
 package symbol.guides.examples.metadata;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.MetadataRepository;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.Address;
-import io.nem.sdk.model.metadata.Metadata;
-import io.nem.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.api.MetadataRepository;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.JsonHelperJackson2;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.metadata.Metadata;
+import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -49,8 +48,8 @@ class GettingMetadataEntriesMosaic {
 
             final List<Metadata> metadata = metadataRepository.getMosaicMetadata(mosaicId, Optional.empty())
                     .toFuture().get();
-            final Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            System.out.println(gson.toJson(metadata));
+            final JsonHelper helper = new JsonHelperJackson2();
+            System.out.println(helper.prettyPrint(metadata));
         }
         /* end block 01 */
     }

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/metadata/GettingMetadataEntriesNamespace.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/metadata/GettingMetadataEntriesNamespace.java
@@ -18,13 +18,13 @@
 
 package symbol.guides.examples.metadata;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.MetadataRepository;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.metadata.Metadata;
-import io.nem.sdk.model.namespace.NamespaceId;
+import io.nem.symbol.sdk.api.MetadataRepository;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.JsonHelperJackson2;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.metadata.Metadata;
+import io.nem.symbol.sdk.model.namespace.NamespaceId;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -43,13 +43,13 @@ class GettingMetadataEntriesNamespace {
             final MetadataRepository metadataRepository = repositoryFactory.createMetadataRepository();
 
             // replace with namespace name
-            final  String namespaceName = "symbol";
+            final String namespaceName = "symbol";
             final NamespaceId namespaceId = NamespaceId.createFromName(namespaceName);
 
             final List<Metadata> metadata = metadataRepository.getNamespaceMetadata(namespaceId, Optional.empty())
                     .toFuture().get();
-            final Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            System.out.println(gson.toJson(metadata));
+            final JsonHelper helper = new JsonHelperJackson2();
+            System.out.println(helper.prettyPrint(metadata));
         }
         /* end block 01 */
     }

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/mosaic/GettingMosaicInformation.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/mosaic/GettingMosaicInformation.java
@@ -18,13 +18,13 @@
 
 package symbol.guides.examples.mosaic;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.MosaicRepository;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.mosaic.MosaicId;
-import io.nem.sdk.model.mosaic.MosaicInfo;
+import io.nem.symbol.sdk.api.MosaicRepository;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.JsonHelperJackson2;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.mosaic.MosaicInfo;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
@@ -49,8 +49,8 @@ class GettingMosaicInformation {
             final MosaicInfo mosaicInfo = mosaicRepository.getMosaic(mosaicId)
                     .toFuture()
                     .get();
-            final Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            System.out.println(gson.toJson(mosaicInfo));
+            final JsonHelper helper = new JsonHelperJackson2();
+            System.out.println(helper.prettyPrint(mosaicInfo));
         }
         /* end block 01 */
     }

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/multisig/GettingMultisigAccountCosignatories.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/multisig/GettingMultisigAccountCosignatories.java
@@ -1,14 +1,15 @@
 package symbol.guides.examples.multisig;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.MultisigRepository;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.Address;
-import io.nem.sdk.model.account.MultisigAccountInfo;
-import java.util.concurrent.ExecutionException;
+import io.nem.symbol.sdk.api.MultisigRepository;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.JsonHelperJackson2;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.account.Address;
+import io.nem.symbol.sdk.model.account.MultisigAccountInfo;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
 
 public class GettingMultisigAccountCosignatories {
 
@@ -32,8 +33,8 @@ public class GettingMultisigAccountCosignatories {
             final MultisigAccountInfo multisigAccountInfo = multisigRepository
                 .getMultisigAccountInfo(address).toFuture().get();
 
-            final Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            System.out.println(gson.toJson(multisigAccountInfo));
+            final JsonHelper helper = new JsonHelperJackson2();
+            System.out.println(helper.prettyPrint(multisigAccountInfo));
             /* end block 01 */
         }
 

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/multisig/ModifyingAMultisigAccountAddCosignatory.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/multisig/ModifyingAMultisigAccountAddCosignatory.java
@@ -18,26 +18,9 @@
 
 package symbol.guides.examples.multisig;
 
-import io.nem.sdk.api.Listener;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.api.TransactionRepository;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.Account;
-import io.nem.sdk.model.account.PublicAccount;
-import io.nem.sdk.model.blockchain.NetworkType;
-import io.nem.sdk.model.mosaic.NetworkCurrencyMosaic;
-import io.nem.sdk.model.transaction.AggregateTransaction;
-import io.nem.sdk.model.transaction.AggregateTransactionFactory;
-import io.nem.sdk.model.transaction.HashLockTransaction;
-import io.nem.sdk.model.transaction.HashLockTransactionFactory;
-import io.nem.sdk.model.transaction.MultisigAccountModificationTransaction;
-import io.nem.sdk.model.transaction.MultisigAccountModificationTransactionFactory;
-import io.nem.sdk.model.transaction.SignedTransaction;
-import io.nem.sdk.model.transaction.Transaction;
-import java.math.BigInteger;
-import java.util.Collections;
-import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
 
 class ModifyingAMultisigAccountAddCosignatory {
 

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/multisig/ModifyingAMultisigAccountIncreaseMinApproval.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/multisig/ModifyingAMultisigAccountIncreaseMinApproval.java
@@ -18,17 +18,17 @@
 
 package symbol.guides.examples.multisig;
 
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.api.TransactionRepository;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.Account;
-import io.nem.sdk.model.account.PublicAccount;
-import io.nem.sdk.model.blockchain.NetworkType;
-import io.nem.sdk.model.transaction.AggregateTransaction;
-import io.nem.sdk.model.transaction.AggregateTransactionFactory;
-import io.nem.sdk.model.transaction.MultisigAccountModificationTransaction;
-import io.nem.sdk.model.transaction.MultisigAccountModificationTransactionFactory;
-import io.nem.sdk.model.transaction.SignedTransaction;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.api.TransactionRepository;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.account.Account;
+import io.nem.symbol.sdk.model.account.PublicAccount;
+import io.nem.symbol.sdk.model.blockchain.NetworkType;
+import io.nem.symbol.sdk.model.transaction.AggregateTransaction;
+import io.nem.symbol.sdk.model.transaction.AggregateTransactionFactory;
+import io.nem.symbol.sdk.model.transaction.MultisigAccountModificationTransaction;
+import io.nem.symbol.sdk.model.transaction.MultisigAccountModificationTransactionFactory;
+import io.nem.symbol.sdk.model.transaction.SignedTransaction;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/namespace/GettingNamespaceInformation.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/namespace/GettingNamespaceInformation.java
@@ -18,16 +18,17 @@
 
 package symbol.guides.examples.namespace;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.NamespaceRepository;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.namespace.NamespaceId;
-import io.nem.sdk.model.namespace.NamespaceInfo;
+import io.nem.symbol.sdk.api.NamespaceRepository;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.JsonHelperJackson2;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.namespace.NamespaceId;
+import io.nem.symbol.sdk.model.namespace.NamespaceInfo;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
+import org.junit.jupiter.api.Test;
+
 import java.net.MalformedURLException;
 import java.util.concurrent.ExecutionException;
-import org.junit.jupiter.api.Test;
 
 class GettingNamespaceInformation {
 
@@ -47,8 +48,8 @@ class GettingNamespaceInformation {
             final NamespaceInfo namespaceInfo = namespaceRepository.getNamespace(namespaceId)
                 .toFuture()
                 .get();
-            final Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            System.out.println(gson.toJson(namespaceInfo));
+            final JsonHelper helper = new JsonHelperJackson2();
+            System.out.println(helper.prettyPrint(namespaceInfo));
         }
     }
     /* end block 01 */

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/AccountAddressRestrictionAllowList.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/AccountAddressRestrictionAllowList.java
@@ -18,8 +18,9 @@
 
 package symbol.guides.examples.restriction;
 
-import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
 
 class AccountAddressRestrictionAllowList {
 

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/AccountAddressRestrictionRemoveRestriction.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/AccountAddressRestrictionRemoveRestriction.java
@@ -18,8 +18,9 @@
 
 package symbol.guides.examples.restriction;
 
-import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
 
 class AccountAddressRestrictionRemoveRestriction {
 

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/AccountMosaicRestrictionBlockList.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/AccountMosaicRestrictionBlockList.java
@@ -18,8 +18,9 @@
 
 package symbol.guides.examples.restriction;
 
-import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
 
 class AccountMosaicRestrictionBlockList {
 

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/GettingAccountRestrictions.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/GettingAccountRestrictions.java
@@ -18,13 +18,13 @@
 
 package symbol.guides.examples.restriction;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.api.RestrictionAccountRepository;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.AccountRestrictions;
-import io.nem.sdk.model.account.Address;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.api.RestrictionAccountRepository;
+import io.nem.symbol.sdk.infrastructure.vertx.JsonHelperJackson2;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.account.AccountRestrictions;
+import io.nem.symbol.sdk.model.account.Address;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
@@ -48,8 +48,8 @@ class GettingAccountRestrictions {
             final AccountRestrictions restrictions = restrictionRepository
                     .getAccountRestrictions(address)
                     .toFuture().get();
-            final Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            System.out.println(gson.toJson(restrictions));
+            final JsonHelper helper = new JsonHelperJackson2();
+            System.out.println(helper.prettyPrint(restrictions));
         }
         /* end block 01 */
     }

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/GettingMosaicAddressRestrictions.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/GettingMosaicAddressRestrictions.java
@@ -18,14 +18,14 @@
 
 package symbol.guides.examples.restriction;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.api.RestrictionMosaicRepository;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.Address;
-import io.nem.sdk.model.mosaic.MosaicId;
-import io.nem.sdk.model.restriction.MosaicAddressRestriction;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.api.RestrictionMosaicRepository;
+import io.nem.symbol.sdk.infrastructure.vertx.JsonHelperJackson2;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.account.Address;
+import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.restriction.MosaicAddressRestriction;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -56,8 +56,8 @@ class GettingMosaicAddressRestrictions {
             restrictions = restrictionRepository
                     .getMosaicAddressRestrictions(mosaicId, Collections.singletonList(address))
                     .toFuture().get();
-            final Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            System.out.println(gson.toJson(restrictions));
+            final JsonHelper helper = new JsonHelperJackson2();
+            System.out.println(helper.prettyPrint(restrictions));
         }
         /* end block 01 */
     }

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/GettingMosaicGlobalRestrictions.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/GettingMosaicGlobalRestrictions.java
@@ -18,13 +18,13 @@
 
 package symbol.guides.examples.restriction;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.api.RestrictionMosaicRepository;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.mosaic.MosaicId;
-import io.nem.sdk.model.restriction.MosaicGlobalRestriction;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.api.RestrictionMosaicRepository;
+import io.nem.symbol.sdk.infrastructure.vertx.JsonHelperJackson2;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.restriction.MosaicGlobalRestriction;
+import io.nem.symbol.sdk.model.transaction.JsonHelper;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -47,12 +47,11 @@ class GettingMosaicGlobalRestrictions {
             final String mosaicIdHex = "634a8ac3fc2b65b3";
             final MosaicId mosaicId = new MosaicId(mosaicIdHex);
 
-            final List<MosaicGlobalRestriction> restrictions;
-            restrictions = restrictionRepository
+            final List<MosaicGlobalRestriction> restrictions = restrictionRepository
                     .getMosaicGlobalRestrictions(Collections.singletonList(mosaicId))
                     .toFuture().get();
-            final Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            System.out.println(gson.toJson(restrictions));
+            final JsonHelper helper = new JsonHelperJackson2();
+            System.out.println(helper.prettyPrint(restrictions));
         }
         /* end block 01 */
     }

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/RestrictingMosaicsTransfersDelegatedMosaicAddressRestriction.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/RestrictingMosaicsTransfersDelegatedMosaicAddressRestriction.java
@@ -18,8 +18,9 @@
 
 package symbol.guides.examples.restriction;
 
-import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
 
 class RestrictingMosaicsTransfersDelegatedMosaicAddressRestriction {
 

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/RestrictingMosaicsTransfersDelegatedMosaicGlobalRestriction.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/RestrictingMosaicsTransfersDelegatedMosaicGlobalRestriction.java
@@ -18,8 +18,9 @@
 
 package symbol.guides.examples.restriction;
 
-import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
 
 class RestrictingMosaicsTransfersDelegatedMosaicGlobalRestriction {
 

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/RestrictingMosaicsTransfersDelegatedMosaicGlobalRestriction2.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/RestrictingMosaicsTransfersDelegatedMosaicGlobalRestriction2.java
@@ -18,8 +18,9 @@
 
 package symbol.guides.examples.restriction;
 
-import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
 
 class RestrictingMosaicsTransfersDelegatedMosaicGlobalRestriction2 {
 

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/RestrictingMosaicsTransfersMosaicAddressRestriction.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/RestrictingMosaicsTransfersMosaicAddressRestriction.java
@@ -18,8 +18,9 @@
 
 package symbol.guides.examples.restriction;
 
-import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
 
 class RestrictingMosaicsTransfersMosaicAddressRestriction {
 

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/RestrictingMosaicsTransfersMosaicGlobalRestriction.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/restriction/RestrictingMosaicsTransfersMosaicGlobalRestriction.java
@@ -18,8 +18,9 @@
 
 package symbol.guides.examples.restriction;
 
-import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
 
 class RestrictingMosaicsTransfersMosaicGlobalRestriction {
 

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/transfer/FirstApplication.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/transfer/FirstApplication.java
@@ -18,19 +18,19 @@
 
 package symbol.guides.examples.transfer;
 
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.api.TransactionRepository;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.Account;
-import io.nem.sdk.model.account.Address;
-import io.nem.sdk.model.account.UnresolvedAddress;
-import io.nem.sdk.model.blockchain.NetworkType;
-import io.nem.sdk.model.message.PlainMessage;
-import io.nem.sdk.model.mosaic.Mosaic;
-import io.nem.sdk.model.mosaic.MosaicId;
-import io.nem.sdk.model.transaction.SignedTransaction;
-import io.nem.sdk.model.transaction.TransferTransaction;
-import io.nem.sdk.model.transaction.TransferTransactionFactory;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.api.TransactionRepository;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.account.Account;
+import io.nem.symbol.sdk.model.account.Address;
+import io.nem.symbol.sdk.model.account.UnresolvedAddress;
+import io.nem.symbol.sdk.model.blockchain.NetworkType;
+import io.nem.symbol.sdk.model.message.PlainMessage;
+import io.nem.symbol.sdk.model.mosaic.Mosaic;
+import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.transaction.SignedTransaction;
+import io.nem.symbol.sdk.model.transaction.TransferTransaction;
+import io.nem.symbol.sdk.model.transaction.TransferTransactionFactory;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/transfer/SendingATransferTransaction.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/transfer/SendingATransferTransaction.java
@@ -18,19 +18,19 @@
 
 package symbol.guides.examples.transfer;
 
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.api.TransactionRepository;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.Account;
-import io.nem.sdk.model.account.Address;
-import io.nem.sdk.model.account.UnresolvedAddress;
-import io.nem.sdk.model.blockchain.NetworkType;
-import io.nem.sdk.model.message.PlainMessage;
-import io.nem.sdk.model.mosaic.Mosaic;
-import io.nem.sdk.model.mosaic.MosaicId;
-import io.nem.sdk.model.transaction.SignedTransaction;
-import io.nem.sdk.model.transaction.TransferTransaction;
-import io.nem.sdk.model.transaction.TransferTransactionFactory;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.api.TransactionRepository;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.account.Account;
+import io.nem.symbol.sdk.model.account.Address;
+import io.nem.symbol.sdk.model.account.UnresolvedAddress;
+import io.nem.symbol.sdk.model.blockchain.NetworkType;
+import io.nem.symbol.sdk.model.message.PlainMessage;
+import io.nem.symbol.sdk.model.mosaic.Mosaic;
+import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.transaction.SignedTransaction;
+import io.nem.symbol.sdk.model.transaction.TransferTransaction;
+import io.nem.symbol.sdk.model.transaction.TransferTransactionFactory;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/transfer/SendingATransferTransactionAddressAlias.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/transfer/SendingATransferTransactionAddressAlias.java
@@ -18,13 +18,13 @@
 
 package symbol.guides.examples.transfer;
 
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.UnresolvedAddress;
-import io.nem.sdk.model.blockchain.NetworkType;
-import io.nem.sdk.model.message.PlainMessage;
-import io.nem.sdk.model.namespace.NamespaceId;
-import io.nem.sdk.model.transaction.TransferTransactionFactory;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.account.UnresolvedAddress;
+import io.nem.symbol.sdk.model.blockchain.NetworkType;
+import io.nem.symbol.sdk.model.message.PlainMessage;
+import io.nem.symbol.sdk.model.namespace.NamespaceId;
+import io.nem.symbol.sdk.model.transaction.TransferTransactionFactory;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/transfer/SendingATransferTransactionMosaicAlias.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/transfer/SendingATransferTransactionMosaicAlias.java
@@ -18,14 +18,14 @@
 
 package symbol.guides.examples.transfer;
 
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.Account;
-import io.nem.sdk.model.blockchain.NetworkType;
-import io.nem.sdk.model.message.PlainMessage;
-import io.nem.sdk.model.mosaic.Mosaic;
-import io.nem.sdk.model.namespace.NamespaceId;
-import io.nem.sdk.model.transaction.TransferTransactionFactory;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.account.Account;
+import io.nem.symbol.sdk.model.blockchain.NetworkType;
+import io.nem.symbol.sdk.model.message.PlainMessage;
+import io.nem.symbol.sdk.model.mosaic.Mosaic;
+import io.nem.symbol.sdk.model.namespace.NamespaceId;
+import io.nem.symbol.sdk.model.transaction.TransferTransactionFactory;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;

--- a/source/resources/examples/java/src/test/java/symbol/guides/examples/transfer/SendingATransferTransactionWithMultipleMosaics.java
+++ b/source/resources/examples/java/src/test/java/symbol/guides/examples/transfer/SendingATransferTransactionWithMultipleMosaics.java
@@ -18,15 +18,15 @@
 
 package symbol.guides.examples.transfer;
 
-import io.nem.sdk.api.RepositoryFactory;
-import io.nem.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
-import io.nem.sdk.model.account.Address;
-import io.nem.sdk.model.account.UnresolvedAddress;
-import io.nem.sdk.model.blockchain.NetworkType;
-import io.nem.sdk.model.message.PlainMessage;
-import io.nem.sdk.model.mosaic.Mosaic;
-import io.nem.sdk.model.mosaic.MosaicId;
-import io.nem.sdk.model.transaction.TransferTransactionFactory;
+import io.nem.symbol.sdk.api.RepositoryFactory;
+import io.nem.symbol.sdk.infrastructure.vertx.RepositoryFactoryVertxImpl;
+import io.nem.symbol.sdk.model.account.Address;
+import io.nem.symbol.sdk.model.account.UnresolvedAddress;
+import io.nem.symbol.sdk.model.blockchain.NetworkType;
+import io.nem.symbol.sdk.model.message.PlainMessage;
+import io.nem.symbol.sdk.model.mosaic.Mosaic;
+import io.nem.symbol.sdk.model.mosaic.MosaicId;
+import io.nem.symbol.sdk.model.transaction.TransferTransactionFactory;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;


### PR DESCRIPTION
Hi @dgarcia360 

This PR upgrades the import packages to the new symbol names. The dependency is still SNAPSHOT until we release it.

I've noticed that you are using GSon for pretty-printing JSON. The Java SDKs (vertx and okhttp) already include a JsonHelper that you can use. It hides the JSON library used (vertx uses Jackson2, okhttp uses GSon). I've committed a small improvement where the corresponding JsonHelper is used (in this case the Jackson one). Gson dependency can be removed, if not the example will bring both GSon and Jackson dependencies.
