### PR TITLE
Simplify finalizedBlock description in the API

### DIFF
--- a/source/api.rst
+++ b/source/api.rst
@@ -144,11 +144,8 @@ Each returned message contains information about a harvested block.
 
 **finalizedBlock**
 
-The ``finalizedBlock`` channel notifies subscribed clients every time a set of blocks is irrevocably added to the blockchain (finalized). Blocks are finalized in rounds (batches) and a single message is sent at the end of each round, containing the height of the highest block in the batch.
-
-Therefore, if you are waiting for a particular block to be finalized, you have to listen for a finalization message with greater or equal block height.
-
-Each returned message contains information about a finalization round.
+The ``finalizedBlock`` channel notifies subscribed clients every time a set of blocks is :ref:`finalized <finalization>`.
+Each returned message contains information about the **highest block** in the finalization round. All blocks with a smaller height are assumed finalized.
 
 *Request body*
 


### PR DESCRIPTION

This is not the place for such a detailed description.
Now that Finalization has been properly described
elsewhere, replace this paragraph with a link.