### PR TITLE
Update the net/node properties guides

### DIFF
--- a/source/_static/config-harvesting.properties.html
+++ b/source/_static/config-harvesting.properties.html
@@ -6,9 +6,9 @@ Harvesting configuration settings.<br/>
 <table class="docutils" style="width:100%; table-layout:fixed;"><thead valign="bottom"><tr class="row-even" style="background-color:#C0C0C0"><th class="head" style="width:35%">Property</th><th class="head" style="width:35%">Type</th><th class="head" style="width:15%">Default value<br/>MIJIN</th><th class="head" style="width:15%">Default value<br/>TESTNET</th></tr></thead><tbody valign="top">
 
 <tr style="background-color:#E0E0E0"><td colspan=4><b>harvesting</b></td><td></td><td></td><td></td></tr>
-<tr><td><code class="docutils literal"><span class="pre">harvesterSigningPrivateKey</span></code></td><td><code class="docutils literal"><span class="pre">string</span></code></td><td></td><td>****************************************************************</td></tr>
+<tr><td><code class="docutils literal"><span class="pre">harvesterSigningPrivateKey</span></code></td><td><code class="docutils literal"><span class="pre">string</span></code></td><td></td><td></td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Harvester signing private key.</small></td></tr>
-<tr><td><code class="docutils literal"><span class="pre">harvesterVrfPrivateKey</span></code></td><td><code class="docutils literal"><span class="pre">string</span></code></td><td></td><td>****************************************************************</td></tr>
+<tr><td><code class="docutils literal"><span class="pre">harvesterVrfPrivateKey</span></code></td><td><code class="docutils literal"><span class="pre">string</span></code></td><td></td><td></td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Harvester vrf private key.</small></td></tr>
 <tr><td><code class="docutils literal"><span class="pre">enableAutoHarvesting</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>false</td><td>true</td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if auto harvesting is enabled.</small></td></tr>

--- a/source/_static/config-harvesting.properties.html
+++ b/source/_static/config-harvesting.properties.html
@@ -1,0 +1,22 @@
+<!-- File generated using catapult-docs-cli -->
+Harvesting configuration settings.<br/>
+<small>From <code class="docutils literal"><span class="pre">resources/config-harvesting.properties</span></code> v0.10.0.3
+</small>
+
+<table class="docutils" style="width:100%; table-layout:fixed;"><thead valign="bottom"><tr class="row-even" style="background-color:#C0C0C0"><th class="head" style="width:35%">Property</th><th class="head" style="width:35%">Type</th><th class="head" style="width:15%">Default value<br/>MIJIN</th><th class="head" style="width:15%">Default value<br/>TESTNET</th></tr></thead><tbody valign="top">
+
+<tr style="background-color:#E0E0E0"><td colspan=4><b>harvesting</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">harvesterSigningPrivateKey</span></code></td><td><code class="docutils literal"><span class="pre">string</span></code></td><td></td><td>****************************************************************</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Harvester signing private key.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">harvesterVrfPrivateKey</span></code></td><td><code class="docutils literal"><span class="pre">string</span></code></td><td></td><td>****************************************************************</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Harvester vrf private key.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableAutoHarvesting</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>false</td><td>true</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if auto harvesting is enabled.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxUnlockedAccounts</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>5</td><td>5</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of unlocked accounts.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">delegatePrioritizationPolicy</span></code></td><td><code class="docutils literal"><span class="pre">harvesting::DelegatePrioritizationPolicy</span></code></td><td>Importance</td><td>Importance</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Delegate harvester prioritization policy.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">beneficiaryAddress</span></code></td><td><code class="docutils literal"><span class="pre">Address</span></code></td><td></td><td></td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Address of the account receiving part of the harvested fee.</small></td></tr>
+</tbody></table>
+

--- a/source/_static/config-inflation.properties.html
+++ b/source/_static/config-inflation.properties.html
@@ -1,0 +1,12 @@
+<!-- File generated using catapult-docs-cli -->
+Inflation configuration settings.<br/>
+<small>From <code class="docutils literal"><span class="pre">resources/config-inflation.properties</span></code> v0.10.0.3
+</small>
+
+<table class="docutils" style="width:100%; table-layout:fixed;"><thead valign="bottom"><tr class="row-even" style="background-color:#C0C0C0"><th class="head" style="width:35%">Property</th><th class="head" style="width:35%">Type</th><th class="head" style="width:15%">Default value<br/>MIJIN</th><th class="head" style="width:15%">Default value<br/>TESTNET</th></tr></thead><tbody valign="top">
+
+<tr style="background-color:#E0E0E0"><td colspan=4><b>inflation</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">starting-at-height-1</span></code></td><td></td><td>100</td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">starting-at-height-10000</span></code></td><td></td><td>0</td><td></td></tr>
+</tbody></table>
+

--- a/source/_static/config-network.properties.html
+++ b/source/_static/config-network.properties.html
@@ -10,9 +10,9 @@ Network configuration settings.<br/>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Network identifier.</small></td></tr>
 <tr><td><code class="docutils literal"><span class="pre">nodeEqualityStrategy</span></code></td><td><code class="docutils literal"><span class="pre">NodeIdentityEqualityStrategy</span></code></td><td>host</td><td>host</td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Node equality strategy.</small></td></tr>
-<tr><td><code class="docutils literal"><span class="pre">nemesisSignerPublicKey</span></code></td><td><code class="docutils literal"><span class="pre">Key</span></code></td><td>C67F465087EF681824805B7E9FF3B2728A4EE847DE044DE5D9FA415F7660B08E</td><td>78F0F6FFDE5C130777506FE2A597ADC5E98BD46041ABF775908299FE94BFD5D0</td></tr>
+<tr><td><code class="docutils literal"><span class="pre">nemesisSignerPublicKey</span></code></td><td><code class="docutils literal"><span class="pre">Key</span></code></td><td></td><td></td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Nemesis public key.</small></td></tr>
-<tr><td><code class="docutils literal"><span class="pre">generationHashSeed</span></code></td><td><code class="docutils literal"><span class="pre">catapult::GenerationHashSeed</span></code></td><td>57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6</td><td>6C1B92391CCB41C96478471C2634C111D9E989DECD66130C0430B5B8D20117CD</td></tr>
+<tr><td><code class="docutils literal"><span class="pre">generationHashSeed</span></code></td><td><code class="docutils literal"><span class="pre">catapult::GenerationHashSeed</span></code></td><td></td><td></td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Nemesis generation hash seed.</small></td></tr>
 <tr><td><code class="docutils literal"><span class="pre">epochAdjustment</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>1573430400s</td><td>1573430400s</td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Nemesis epoch time adjustment.</small></td></tr>
@@ -21,9 +21,9 @@ Network configuration settings.<br/>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if block chain should calculate state hashes so that state is fully verifiable at each block.</small></td></tr>
 <tr><td><code class="docutils literal"><span class="pre">enableVerifiableReceipts</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>true</td><td>true</td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if block chain should calculate receipts so that state changes are fully verifiable at each block.</small></td></tr>
-<tr><td><code class="docutils literal"><span class="pre">currencyMosaicId</span></code></td><td><code class="docutils literal"><span class="pre">MosaicId</span></code></td><td>0x24F4'26B8'D549'3D4B</td><td>0x5B66'E76B'ECAD'0860</td></tr>
+<tr><td><code class="docutils literal"><span class="pre">currencyMosaicId</span></code></td><td><code class="docutils literal"><span class="pre">MosaicId</span></code></td><td></td><td></td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Mosaic id used as primary chain currency.</small></td></tr>
-<tr><td><code class="docutils literal"><span class="pre">harvestingMosaicId</span></code></td><td><code class="docutils literal"><span class="pre">MosaicId</span></code></td><td>0x1D9C'DC7E'218C'A88D</td><td>0x5B66'E76B'ECAD'0860</td></tr>
+<tr><td><code class="docutils literal"><span class="pre">harvestingMosaicId</span></code></td><td><code class="docutils literal"><span class="pre">MosaicId</span></code></td><td></td><td></td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Mosaic id used to provide harvesting ability.</small></td></tr>
 <tr><td><code class="docutils literal"><span class="pre">blockGenerationTargetTime</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>30s</td><td>30s</td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Targeted time between blocks.</small></td></tr>
@@ -67,7 +67,7 @@ Network configuration settings.<br/>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Percentage of the harvested fee that is collected by the beneficiary account.</small></td></tr>
 <tr><td><code class="docutils literal"><span class="pre">harvestNetworkPercentage</span></code></td><td><code class="docutils literal"><span class="pre">uint8_t</span></code></td><td>5</td><td>5</td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Percentage of the harvested fee that is collected by the network.</small></td></tr>
-<tr><td><code class="docutils literal"><span class="pre">harvestNetworkFeeSinkAddress</span></code></td><td><code class="docutils literal"><span class="pre">Address</span></code></td><td>SBPJ3LE4SF7Y25RCEC6MA5BXBP6W2TGB2XKMIDY</td><td>TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q</td></tr>
+<tr><td><code class="docutils literal"><span class="pre">harvestNetworkFeeSinkAddress</span></code></td><td><code class="docutils literal"><span class="pre">Address</span></code></td><td></td><td></td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Address of the harvest network fee sink account.</small></td></tr>
 <tr><td><code class="docutils literal"><span class="pre">maxTransactionsPerBlock</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>200'000</td><td>6'000</td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of transactions per block.</small></td></tr>
@@ -106,7 +106,7 @@ Network configuration settings.<br/>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum mosaic duration.</small></td></tr>
 <tr><td><code class="docutils literal"><span class="pre">maxMosaicDivisibility</span></code></td><td><code class="docutils literal"><span class="pre">uint8_t</span></code></td><td>6</td><td>6</td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum mosaic divisibility.</small></td></tr>
-<tr><td><code class="docutils literal"><span class="pre">mosaicRentalFeeSinkAddress</span></code></td><td><code class="docutils literal"><span class="pre">Address</span></code></td><td>SDKDPA36TE53BO24FD4KA6OPGOUSEVOU3O5SIFI</td><td>TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q</td></tr>
+<tr><td><code class="docutils literal"><span class="pre">mosaicRentalFeeSinkAddress</span></code></td><td><code class="docutils literal"><span class="pre">Address</span></code></td><td></td><td></td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Address of the mosaic rental fee sink account.</small></td></tr>
 <tr><td><code class="docutils literal"><span class="pre">mosaicRentalFee</span></code></td><td><code class="docutils literal"><span class="pre">Amount</span></code></td><td>500</td><td>500</td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Mosaic rental fee.</small></td></tr>
@@ -132,7 +132,7 @@ Network configuration settings.<br/>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Grace period during which time only the previous owner can renew an expired namespace.</small></td></tr>
 <tr><td><code class="docutils literal"><span class="pre">reservedRootNamespaceNames</span></code></td><td><code class="docutils literal"><span class="pre">unordered_set<string></span></code></td><td>xem, nem, user, account, org, com, biz, net, edu, mil, gov, info</td><td>symbol, symbl, xym, xem, nem, user, account, org, com, biz, net, edu, mil, gov, info</td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Reserved root namespaces that cannot be claimed.</small></td></tr>
-<tr><td><code class="docutils literal"><span class="pre">namespaceRentalFeeSinkAddress</span></code></td><td><code class="docutils literal"><span class="pre">Address</span></code></td><td>SDTZ23JBJZP3GTKKM2P6FYCMXS6RQYPB6R477TQ</td><td>TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q</td></tr>
+<tr><td><code class="docutils literal"><span class="pre">namespaceRentalFeeSinkAddress</span></code></td><td><code class="docutils literal"><span class="pre">Address</span></code></td><td></td><td></td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Address of the namespace rental fee sink account.</small></td></tr>
 <tr><td><code class="docutils literal"><span class="pre">rootNamespaceRentalFeePerBlock</span></code></td><td><code class="docutils literal"><span class="pre">Amount</span></code></td><td>1</td><td>1</td></tr>
 <tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Root namespace rental fee per block.</small></td></tr>

--- a/source/_static/config-network.properties.html
+++ b/source/_static/config-network.properties.html
@@ -1,0 +1,151 @@
+<!-- File generated using catapult-docs-cli -->
+Network configuration settings.<br/>
+<small>From <code class="docutils literal"><span class="pre">resources/config-network.properties</span></code> v0.10.0.3
+</small>
+
+<table class="docutils" style="width:100%; table-layout:fixed;"><thead valign="bottom"><tr class="row-even" style="background-color:#C0C0C0"><th class="head" style="width:35%">Property</th><th class="head" style="width:35%">Type</th><th class="head" style="width:15%">Default value<br/>MIJIN</th><th class="head" style="width:15%">Default value<br/>TESTNET</th></tr></thead><tbody valign="top">
+
+<tr style="background-color:#E0E0E0"><td colspan=4><b>network</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">identifier</span></code></td><td><code class="docutils literal"><span class="pre">NetworkIdentifier</span></code></td><td>mijin-test</td><td>public-test</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Network identifier.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">nodeEqualityStrategy</span></code></td><td><code class="docutils literal"><span class="pre">NodeIdentityEqualityStrategy</span></code></td><td>host</td><td>host</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Node equality strategy.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">nemesisSignerPublicKey</span></code></td><td><code class="docutils literal"><span class="pre">Key</span></code></td><td>C67F465087EF681824805B7E9FF3B2728A4EE847DE044DE5D9FA415F7660B08E</td><td>78F0F6FFDE5C130777506FE2A597ADC5E98BD46041ABF775908299FE94BFD5D0</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Nemesis public key.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">generationHashSeed</span></code></td><td><code class="docutils literal"><span class="pre">catapult::GenerationHashSeed</span></code></td><td>57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6</td><td>6C1B92391CCB41C96478471C2634C111D9E989DECD66130C0430B5B8D20117CD</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Nemesis generation hash seed.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">epochAdjustment</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>1573430400s</td><td>1573430400s</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Nemesis epoch time adjustment.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>chain</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableVerifiableState</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>true</td><td>true</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if block chain should calculate state hashes so that state is fully verifiable at each block.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableVerifiableReceipts</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>true</td><td>true</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if block chain should calculate receipts so that state changes are fully verifiable at each block.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">currencyMosaicId</span></code></td><td><code class="docutils literal"><span class="pre">MosaicId</span></code></td><td>0x24F4'26B8'D549'3D4B</td><td>0x5B66'E76B'ECAD'0860</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Mosaic id used as primary chain currency.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">harvestingMosaicId</span></code></td><td><code class="docutils literal"><span class="pre">MosaicId</span></code></td><td>0x1D9C'DC7E'218C'A88D</td><td>0x5B66'E76B'ECAD'0860</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Mosaic id used to provide harvesting ability.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">blockGenerationTargetTime</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>30s</td><td>30s</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Targeted time between blocks.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">blockTimeSmoothingFactor</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>3000</td><td>3000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Smoothing factor in thousandths. If this value is non-zero, the network will be biased in favor of evenly spaced blocks. <br/><b>Note</b>: A higher value makes the network more biased. <br/><b>Note</b>: This can lower security because it will increase the influence of time relative to importance.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">importanceGrouping</span></code></td><td><code class="docutils literal"><span class="pre">uint64_t</span></code></td><td>39</td><td>180</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Number of blocks that should be treated as a group for importance purposes. <br/><b>Note</b>: Importances will only be calculated at blocks that are multiples of this grouping number.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">importanceActivityPercentage</span></code></td><td><code class="docutils literal"><span class="pre">uint8_t</span></code></td><td>5</td><td>5</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Percentage of importance resulting from fee generation and beneficiary usage.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxRollbackBlocks</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>40</td><td>0</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of blocks that can be rolled back.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxDifficultyBlocks</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>60</td><td>60</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of blocks to use in a difficulty calculation.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">defaultDynamicFeeMultiplier</span></code></td><td><code class="docutils literal"><span class="pre">BlockFeeMultiplier</span></code></td><td>10'000</td><td>1'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Default multiplier to use for dynamic fees.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxTransactionLifetime</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>24h</td><td>6h</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum lifetime a transaction can have before it expires.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxBlockFutureTime</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>500ms</td><td>500ms</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum future time of a block that can be accepted.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">initialCurrencyAtomicUnits</span></code></td><td><code class="docutils literal"><span class="pre">Amount</span></code></td><td>8'998'999'998'000'000</td><td>7'831'975'436'000'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Initial currency atomic units available in the network.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxMosaicAtomicUnits</span></code></td><td><code class="docutils literal"><span class="pre">Amount</span></code></td><td>9'000'000'000'000'000</td><td>9'000'000'000'000'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum atomic units (total-supply * 10 ^ divisibility) of a mosaic allowed in the network.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">totalChainImportance</span></code></td><td><code class="docutils literal"><span class="pre">Importance</span></code></td><td>15'000'000</td><td>7'831'975'436'000'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Total whole importance units available in the network.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">minHarvesterBalance</span></code></td><td><code class="docutils literal"><span class="pre">Amount</span></code></td><td>500</td><td>10'000'000'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Minimum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxHarvesterBalance</span></code></td><td><code class="docutils literal"><span class="pre">Amount</span></code></td><td>4'000'000</td><td>50'000'000'000'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">minVoterBalance</span></code></td><td><code class="docutils literal"><span class="pre">Amount</span></code></td><td>50'000</td><td>3'000'000'000'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Minimum number of harvesting mosaic atomic units needed for an account to be eligible for voting.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">votingSetGrouping</span></code></td><td><code class="docutils literal"><span class="pre">uint64_t</span></code></td><td>100</td><td>720</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Number of blocks that should be treated as a group for voting set purposes. <br/><b>Note</b>: Voting sets will only be calculated at blocks that are multiples of this grouping number.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxVotingKeysPerAccount</span></code></td><td><code class="docutils literal"><span class="pre">uint8_t</span></code></td><td>3</td><td>3</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of voting keys that can be registered at once per account.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">minVotingKeyLifetime</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>72</td><td>28</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Minimum number of finalization rounds for which voting key can be registered.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxVotingKeyLifetime</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>26280</td><td>26280</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of finalization rounds for which voting key can be registered.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">harvestBeneficiaryPercentage</span></code></td><td><code class="docutils literal"><span class="pre">uint8_t</span></code></td><td>10</td><td>25</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Percentage of the harvested fee that is collected by the beneficiary account.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">harvestNetworkPercentage</span></code></td><td><code class="docutils literal"><span class="pre">uint8_t</span></code></td><td>5</td><td>5</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Percentage of the harvested fee that is collected by the network.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">harvestNetworkFeeSinkAddress</span></code></td><td><code class="docutils literal"><span class="pre">Address</span></code></td><td>SBPJ3LE4SF7Y25RCEC6MA5BXBP6W2TGB2XKMIDY</td><td>TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Address of the harvest network fee sink account.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxTransactionsPerBlock</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>200'000</td><td>6'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of transactions per block.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>plugin:catapult.plugins.accountlink</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">dummy</span></code></td><td></td><td>to trigger plugin load</td><td>to trigger plugin load</td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>plugin:catapult.plugins.aggregate</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxTransactionsPerAggregate</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>1'000</td><td>100</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of transactions per aggregate.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxCosignaturesPerAggregate</span></code></td><td><code class="docutils literal"><span class="pre">uint8_t</span></code></td><td>15</td><td>25</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of cosignatures per aggregate.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableStrictCosignatureCheck</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>false</td><td>false</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if cosignatures must exactly match component signers. <code class="docutils literal"><span class="pre">false</span></code> if cosignatures should be validated externally.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableBondedAggregateSupport</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>true</td><td>true</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if bonded aggregates should be allowed. <code class="docutils literal"><span class="pre">false</span></code> if bonded aggregates should be rejected.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxBondedTransactionLifetime</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>48h</td><td>48h</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum lifetime a bonded transaction can have before it expires.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>plugin:catapult.plugins.lockhash</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">lockedFundsPerAggregate</span></code></td><td><code class="docutils literal"><span class="pre">Amount</span></code></td><td>10'000'000</td><td>10'000'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Amount that has to be locked per aggregate in partial cache.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxHashLockDuration</span></code></td><td><code class="docutils literal"><span class="pre">utils::BlockSpan</span></code></td><td>2d</td><td>2d</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of blocks for which a hash lock can exist.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>plugin:catapult.plugins.locksecret</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxSecretLockDuration</span></code></td><td><code class="docutils literal"><span class="pre">utils::BlockSpan</span></code></td><td>30d</td><td>365d</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of blocks for which a secret lock can exist.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">minProofSize</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>1</td><td>20</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Minimum size of a proof in bytes.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxProofSize</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>1000</td><td>1024</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum size of a proof in bytes.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>plugin:catapult.plugins.metadata</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxValueSize</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>1024</td><td>1024</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum metadata value size.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>plugin:catapult.plugins.mosaic</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxMosaicsPerAccount</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>10'000</td><td>1'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of mosaics that an account can own.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxMosaicDuration</span></code></td><td><code class="docutils literal"><span class="pre">utils::BlockSpan</span></code></td><td>3650d</td><td>3650d</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum mosaic duration.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxMosaicDivisibility</span></code></td><td><code class="docutils literal"><span class="pre">uint8_t</span></code></td><td>6</td><td>6</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum mosaic divisibility.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">mosaicRentalFeeSinkAddress</span></code></td><td><code class="docutils literal"><span class="pre">Address</span></code></td><td>SDKDPA36TE53BO24FD4KA6OPGOUSEVOU3O5SIFI</td><td>TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Address of the mosaic rental fee sink account.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">mosaicRentalFee</span></code></td><td><code class="docutils literal"><span class="pre">Amount</span></code></td><td>500</td><td>500</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Mosaic rental fee.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>plugin:catapult.plugins.multisig</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxMultisigDepth</span></code></td><td><code class="docutils literal"><span class="pre">uint8_t</span></code></td><td>3</td><td>3</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of multisig levels.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxCosignatoriesPerAccount</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>10</td><td>25</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of cosignatories per account.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxCosignedAccountsPerAccount</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>5</td><td>25</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of accounts a single account can cosign.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>plugin:catapult.plugins.namespace</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxNameSize</span></code></td><td><code class="docutils literal"><span class="pre">uint8_t</span></code></td><td>64</td><td>64</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum namespace name size.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxChildNamespaces</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>500</td><td>256</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of children for a root namespace.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxNamespaceDepth</span></code></td><td><code class="docutils literal"><span class="pre">uint8_t</span></code></td><td>3</td><td>3</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum namespace depth.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">minNamespaceDuration</span></code></td><td><code class="docutils literal"><span class="pre">utils::BlockSpan</span></code></td><td>1m</td><td>30d</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Minimum namespace duration.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxNamespaceDuration</span></code></td><td><code class="docutils literal"><span class="pre">utils::BlockSpan</span></code></td><td>365d</td><td>1825d</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum namespace duration.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">namespaceGracePeriodDuration</span></code></td><td><code class="docutils literal"><span class="pre">utils::BlockSpan</span></code></td><td>2m</td><td>1d</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Grace period during which time only the previous owner can renew an expired namespace.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">reservedRootNamespaceNames</span></code></td><td><code class="docutils literal"><span class="pre">unordered_set<string></span></code></td><td>xem, nem, user, account, org, com, biz, net, edu, mil, gov, info</td><td>symbol, symbl, xym, xem, nem, user, account, org, com, biz, net, edu, mil, gov, info</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Reserved root namespaces that cannot be claimed.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">namespaceRentalFeeSinkAddress</span></code></td><td><code class="docutils literal"><span class="pre">Address</span></code></td><td>SDTZ23JBJZP3GTKKM2P6FYCMXS6RQYPB6R477TQ</td><td>TDGY4DD2U4YQQGERFMDQYHPYS6M7LHIF6XUCJ4Q</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Address of the namespace rental fee sink account.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">rootNamespaceRentalFeePerBlock</span></code></td><td><code class="docutils literal"><span class="pre">Amount</span></code></td><td>1</td><td>1</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Root namespace rental fee per block.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">childNamespaceRentalFee</span></code></td><td><code class="docutils literal"><span class="pre">Amount</span></code></td><td>100</td><td>100</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Child namespace rental fee.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>plugin:catapult.plugins.restrictionaccount</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxAccountRestrictionValues</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>512</td><td>512</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of account restriction values.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>plugin:catapult.plugins.restrictionmosaic</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxMosaicRestrictionValues</span></code></td><td><code class="docutils literal"><span class="pre">uint8_t</span></code></td><td>20</td><td>20</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of mosaic restriction values.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>plugin:catapult.plugins.transfer</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxMessageSize</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>1024</td><td>1024</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum transaction message size.</small></td></tr>
+</tbody></table>
+

--- a/source/_static/config-node.properties.html
+++ b/source/_static/config-node.properties.html
@@ -1,0 +1,122 @@
+<!-- File generated using catapult-docs-cli -->
+Node configuration settings.<br/>
+<small>From <code class="docutils literal"><span class="pre">resources/config-node.properties</span></code> v0.10.0.3
+</small>
+
+<table class="docutils" style="width:100%; table-layout:fixed;"><thead valign="bottom"><tr class="row-even" style="background-color:#C0C0C0"><th class="head" style="width:35%">Property</th><th class="head" style="width:35%">Type</th><th class="head" style="width:15%">Default value<br/>MIJIN</th><th class="head" style="width:15%">Default value<br/>TESTNET</th></tr></thead><tbody valign="top">
+
+<tr style="background-color:#E0E0E0"><td colspan=4><b>node</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">port</span></code></td><td><code class="docutils literal"><span class="pre">unsigned short</span></code></td><td>7900</td><td>7900</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Server port.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxIncomingConnectionsPerIdentity</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>3</td><td>6</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of incoming connections per identity over primary port.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableAddressReuse</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>false</td><td>false</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if the server should reuse ports already in use.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableSingleThreadPool</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>false</td><td>true</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if a single thread pool should be used, <code class="docutils literal"><span class="pre">false</span></code> if multiple thread pools should be used.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableCacheDatabaseStorage</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>true</td><td>true</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if cache data should be saved in a database.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableAutoSyncCleanup</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>true</td><td>true</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if temporary sync files should be automatically cleaned up. <br/><b>Note</b>: This should be <code class="docutils literal"><span class="pre">false</span></code> if broker process is running.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableTransactionSpamThrottling</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>true</td><td>true</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if transaction spam throttling should be enabled.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">transactionSpamThrottlingMaxBoostFee</span></code></td><td><code class="docutils literal"><span class="pre">Amount</span></code></td><td>10'000'000</td><td>10'000'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum fee that will boost a transaction through the spam throttle when spam throttling is enabled.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxHashesPerSyncAttempt</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>84</td><td>610</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of hashes per sync attempt.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxBlocksPerSyncAttempt</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>42</td><td>602</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of blocks per sync attempt.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxChainBytesPerSyncAttempt</span></code></td><td><code class="docutils literal"><span class="pre">utils::FileSize</span></code></td><td>100MB</td><td>100MB</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum chain bytes per sync attempt.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">shortLivedCacheTransactionDuration</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>10m</td><td>10m</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Duration of a transaction in the short lived cache.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">shortLivedCacheBlockDuration</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>100m</td><td>100m</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Duration of a block in the short lived cache.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">shortLivedCachePruneInterval</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>90s</td><td>90s</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Time between short lived cache pruning.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">shortLivedCacheMaxSize</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>10'000'000</td><td>200'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum size of a short lived cache.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">minFeeMultiplier</span></code></td><td><code class="docutils literal"><span class="pre">BlockFeeMultiplier</span></code></td><td>0</td><td>100</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Minimum fee multiplier of transactions to propagate and include in blocks.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">transactionSelectionStrategy</span></code></td><td><code class="docutils literal"><span class="pre">model::TransactionSelectionStrategy</span></code></td><td>oldest</td><td>maximize-fee</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Transaction selection strategy used for syncing and harvesting unconfirmed transactions.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">unconfirmedTransactionsCacheMaxResponseSize</span></code></td><td><code class="docutils literal"><span class="pre">utils::FileSize</span></code></td><td>20MB</td><td>20MB</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum size of an unconfirmed transactions response.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">unconfirmedTransactionsCacheMaxSize</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>1'000'000</td><td>50'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum size of the unconfirmed transactions cache.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">connectTimeout</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>10s</td><td>15s</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Timeout for connecting to a peer.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">syncTimeout</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>60s</td><td>120s</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Timeout for syncing with a peer.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">socketWorkingBufferSize</span></code></td><td><code class="docutils literal"><span class="pre">utils::FileSize</span></code></td><td>512KB</td><td>512KB</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Initial socket working buffer size (socket reads will attempt to read buffers of roughly this size).</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">socketWorkingBufferSensitivity</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>100</td><td>100</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Socket working buffer sensitivity (lower values will cause memory to be more aggressively reclaimed). <br/><b>Note</b>: <code class="docutils literal"><span class="pre">0</span></code> will disable memory reclamation.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxPacketDataSize</span></code></td><td><code class="docutils literal"><span class="pre">utils::FileSize</span></code></td><td>150MB</td><td>150MB</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum packet data size.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">blockDisruptorSize</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>4096</td><td>4096</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Size of the block disruptor circular buffer.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">blockElementTraceInterval</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>1</td><td>1</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Multiple of elements at which a block element should be traced through queue and completion.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">transactionDisruptorSize</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>16384</td><td>16384</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Size of the transaction disruptor circular buffer.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">transactionElementTraceInterval</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>10</td><td>10</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Multiple of elements at which a transaction element should be traced through queue and completion.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableDispatcherAbortWhenFull</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>true</td><td>false</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if the process should terminate when any dispatcher is full.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableDispatcherInputAuditing</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>true</td><td>false</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if all dispatcher inputs should be audited.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxCacheDatabaseWriteBatchSize</span></code></td><td><code class="docutils literal"><span class="pre">utils::FileSize</span></code></td><td>5MB</td><td>5MB</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum cache database write batch size.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxTrackedNodes</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>5'000</td><td>5'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of nodes to track in memory.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">trustedHosts</span></code></td><td><code class="docutils literal"><span class="pre">unordered_set<string></span></code></td><td></td><td></td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Trusted hosts that are allowed to execute protected API calls on this node.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">localNetworks</span></code></td><td><code class="docutils literal"><span class="pre">unordered_set<string></span></code></td><td>127.0.0.1</td><td>127.0.0.1</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Networks that should be treated as local.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>localnode</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">host</span></code></td><td><code class="docutils literal"><span class="pre">string</span></code></td><td></td><td></td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Node host (leave empty to auto-detect IP).</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">friendlyName</span></code></td><td><code class="docutils literal"><span class="pre">string</span></code></td><td></td><td>915772a</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Node friendly name (leave empty to use address).</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">version</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>0</td><td>0</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Node version.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">roles</span></code></td><td><code class="docutils literal"><span class="pre">ionet::NodeRoles</span></code></td><td>Peer</td><td>Peer</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Node roles.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>outgoing_connections</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxConnections</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>10</td><td>10</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of active connections.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxConnectionAge</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>200</td><td>200</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum connection age.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxConnectionBanAge</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>20</td><td>20</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum connection ban age.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">numConsecutiveFailuresBeforeBanning</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>3</td><td>3</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Number of consecutive connection failures before a connection is banned.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>incoming_connections</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxConnections</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>512</td><td>512</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of active connections.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxConnectionAge</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>200</td><td>200</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum connection age.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxConnectionBanAge</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>20</td><td>20</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum connection ban age.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">numConsecutiveFailuresBeforeBanning</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>3</td><td>3</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Number of consecutive connection failures before a connection is banned.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">backlogSize</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>512</td><td>512</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum size of the pending connections queue.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>banning</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">defaultBanDuration</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>12h</td><td>12h</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Default duration for banning.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxBanDuration</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>72h</td><td>12h</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum duration for banning.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">keepAliveDuration</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>48h</td><td>48h</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Duration to keep account in container after the ban expired.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxBannedNodes</span></code></td><td><code class="docutils literal"><span class="pre">uint32_t</span></code></td><td>5'000</td><td>5'000</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum number of banned nodes.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">numReadRateMonitoringBuckets</span></code></td><td><code class="docutils literal"><span class="pre">uint16_t</span></code></td><td>4</td><td>4</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Number of read rate monitoring buckets (<code class="docutils literal"><span class="pre">0</span></code> to disable read rate monitoring).</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">readRateMonitoringBucketDuration</span></code></td><td><code class="docutils literal"><span class="pre">utils::TimeSpan</span></code></td><td>15s</td><td>15s</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Duration of each read rate monitoring bucket.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">maxReadRateMonitoringTotalSize</span></code></td><td><code class="docutils literal"><span class="pre">utils::FileSize</span></code></td><td>100MB</td><td>100MB</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Maximum size allowed during full read rate monitoring period.</small></td></tr>
+</tbody></table>
+

--- a/source/_static/config-user.properties.html
+++ b/source/_static/config-user.properties.html
@@ -1,0 +1,21 @@
+<!-- File generated using catapult-docs-cli -->
+User configuration settings.<br/>
+<small>From <code class="docutils literal"><span class="pre">resources/config-user.properties</span></code> v0.10.0.3
+</small>
+
+<table class="docutils" style="width:100%; table-layout:fixed;"><thead valign="bottom"><tr class="row-even" style="background-color:#C0C0C0"><th class="head" style="width:35%">Property</th><th class="head" style="width:35%">Type</th><th class="head" style="width:15%">Default value<br/>MIJIN</th><th class="head" style="width:15%">Default value<br/>TESTNET</th></tr></thead><tbody valign="top">
+
+<tr style="background-color:#E0E0E0"><td colspan=4><b>account</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">enableDelegatedHarvestersAutoDetection</span></code></td><td><code class="docutils literal"><span class="pre">bool</span></code></td><td>true</td><td>true</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small><code class="docutils literal"><span class="pre">true</span></code> if potential delegated harvesters should be automatically detected.</small></td></tr>
+<tr style="background-color:#E0E0E0"><td colspan=4><b>storage</b></td><td></td><td></td><td></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">dataDirectory</span></code></td><td><code class="docutils literal"><span class="pre">string</span></code></td><td>../data</td><td>./data</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Data directory.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">certificateDirectory</span></code></td><td><code class="docutils literal"><span class="pre">string</span></code></td><td>../certificate</td><td>./userconfig/resources/cert</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Certificate directory.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">votingKeysDirectory</span></code></td><td><code class="docutils literal"><span class="pre">string</span></code></td><td>../votingkeys</td><td>./data/votingkeys</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Voting keys directory.</small></td></tr>
+<tr><td><code class="docutils literal"><span class="pre">pluginsDirectory</span></code></td><td><code class="docutils literal"><span class="pre">string</span></code></td><td>.</td><td>/usr/catapult/lib</td></tr>
+<tr><td colspan="4" style="border-top: none; padding-left:32px"><small>Plugins directory.</small></td></tr>
+</tbody></table>
+

--- a/source/guides/network/configuring-network-properties.rst
+++ b/source/guides/network/configuring-network-properties.rst
@@ -9,11 +9,13 @@
 Configuring network properties
 ##############################
 
-|symbol-bootstrap| (read the :doc:`Using Symbol Bootstrap<using-symbol-bootstrap>` guide if you don't know what it is) accepts custom presets to customize the network to your needs.
+There is a large number of network-related settings that can be customized in |codename|.
 
-The tables below list all the network-related properties that can be set. Put them in a YAML file and pass it to ``symbol-bootstrap config`` using the ``-c`` parameter.
+The easiest way to change them is by using |symbol-bootstrap|'s custom presets (read :doc:`Using Symbol Bootstrap<using-symbol-bootstrap>`): Put the settings in a YAML file and pass it to ``symbol-bootstrap config`` using the ``-c`` parameter.
 
-For node-related properties, read the :doc:`Configuring node properties <configuring-node-properties>` guide.
+These settings can also be directly provided to |catapult-server| through ``.properties`` files. The header of each of the tables below indicates which file contains that table's properties.
+
+.. note:: For **node**-related properties, read the :doc:`Configuring node properties <configuring-node-properties>` guide.
 
 .. _config-network-properties:
 
@@ -34,3 +36,7 @@ Inflation configuration
 .. |symbol-bootstrap| raw:: html
 
    <a href="https://github.com/nemtech/symbol-bootstrap" target="_blank">Symbol Bootstrap</a>
+
+.. |catapult-server| raw:: html
+
+   <a href="https://github.com/nemtech/catapult-server" target="_blank">catapult-server</a>

--- a/source/guides/network/configuring-network-properties.rst
+++ b/source/guides/network/configuring-network-properties.rst
@@ -9,118 +9,28 @@
 Configuring network properties
 ##############################
 
-Customize the network configurable parameters.
+|symbol-bootstrap| (read the :doc:`Using Symbol Bootstrap<using-symbol-bootstrap>` guide if you don't know what it is) accepts custom presets to customize the network to your needs.
 
-The directory ``ruby/catapult-templates/peer_node/resources`` of the |catapult-service-bootstrap| repository comes with a set of files to configure the network.
+The tables below list all the network-related properties that can be set. Put them in a YAML file and pass it to ``symbol-bootstrap config`` using the ``-c`` parameter.
 
-The ``.properties`` files provided can be edited with any text editor before launching a network for the first time.
-
-**********
-Properties
-**********
-
-Find below the list of configurable properties.
+For node-related properties, read the :doc:`Configuring node properties <configuring-node-properties>` guide.
 
 .. _config-network-properties:
 
-config-network.properties
-=========================
+*********************
+Network configuration
+*********************
 
-.. csv-table::
-    :header: "Property", "Type", "Description", "Default MIJIN_TEST", "Default TEST_NET"
-    :delim: ;
+.. raw:: html
+    :file: ../../_static/config-network.properties.html
 
-    **network**; ; ; ;
-    identifier; NetworkIdentifier; Network identifier.; mijin-test; public-test
-    nodeEqualityStrategy; NodeIdentityEqualityStrategy; Node equality strategy.; host; host
-    nemesisSignerPublicKey; Key; Nemesis public key.; B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF;
-    generationHash; catapult::GenerationHash; Nemesis generation hash.; 57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6;
-    epochAdjustment; utils::TimeSpan; Nemesis epoch time adjustment.; 1573430400s; 1573430400s
-    **chain**; ; ; ;
-    enableVerifiableState; bool; Set to true if block chain should calculate state hashes so that state is fully verifiable at each block.; true; true
-    enableVerifiableReceipts; bool; Set to true if block chain should calculate receipts so that state changes are fully verifiable at each block.; true; true
-    currencyMosaicId; MosaicId; Mosaic id used as primary chain currency.; 0x24F4'26B8'D549'3D4B;
-    harvestingMosaicId; MosaicId; Mosaic id used to provide harvesting ability.; 0x1D9C'DC7E'218C'A88D;
-    blockGenerationTargetTime; utils::TimeSpan; Targeted time between blocks.; 30s; 15s
-    blockTimeSmoothingFactor; uint32_t; *Note*: A higher value makes the network more biased. *Note*: This can lower security because it will increase the influence of time relative to importance.; 3000; 3000
-    blockFinalizationInterval; uint32_t; Number of blocks between successive finalization attempts.; 30;
-    importanceGrouping; uint64_t; Number of blocks that should be treated as a group for importance purposes. *Note*: Importances will only be calculated at blocks that are multiples of this grouping number.; 39; 1433
-    importanceActivityPercentage; uint8_t; Percentage of importance resulting from fee generation and beneficiary usage.; 5; 5
-    maxRollbackBlocks; uint32_t; Maximum number of blocks that can be rolled back.; 40; 398
-    maxDifficultyBlocks; uint32_t; Maximum number of blocks to use in a difficulty calculation.; 60; 60
-    defaultDynamicFeeMultiplier; BlockFeeMultiplier; Default multiplier to use for dynamic fees.; 10'000; 1'000
-    maxTransactionLifetime; utils::TimeSpan; Maximum lifetime a transaction can have before it expires.; 24h; 24h
-    maxBlockFutureTime; utils::TimeSpan; Maximum future time of a block that can be accepted.; 500ms; 500ms
-    initialCurrencyAtomicUnits; Amount; Initial currency atomic units available in the network.; 8'998'999'998'000'000; 7'831'975'436'000'000
-    maxMosaicAtomicUnits; Amount; Maximum atomic units (total-supply * 10 ^ divisibility) of a mosaic allowed in the network.; 9'000'000'000'000'000; 9'000'000'000'000'000
-    totalChainImportance; Importance; Total whole importance units available in the network.; 15'000'000; 7'831'975'436'000'000
-    minHarvesterBalance; Amount; Minimum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting.; 500; 10'000'000'000
-    maxHarvesterBalance; Amount; Maximum number of harvesting mosaic atomic units needed for an account to be eligible for harvesting.; 4'000'000; 50'000'000'000'000
-    minVoterBalance; Amount; Minimum number of harvesting mosaic atomic units needed for an account to be eligible for voting.; 50'000; 50'000
-    maxVotingKeysPerAccount; uint8_t; Maximum number of voting keys that can be registered at once per account.; 3; 
-    minVotingKeyLifetime; uint32_t; Minimum number of finalization rounds for which voting key can be registered.; 72;
-    maxVotingKeyLifetime; uint32_t; Maximum number of finalization rounds for which voting key can be registered.; 26280;
-    harvestBeneficiaryPercentage; uint8_t; Percentage of the harvested fee that is collected by the beneficiary account.; 10; 25
-    harvestNetworkPercentage; uint8_t; Percentage of the harvested fee that is collected by the network.; 5; 5
-    harvestNetworkFeeSinkAddress; Address; Address of the harvest network fee sink account.; SBPJ3LE4SF7Y25RCEC6MA5BXBP6W2TGB2XKMIDY;
-    blockPruneInterval; uint32_t; Number of blocks between cache pruning.; 360; 360
-    maxTransactionsPerBlock; uint32_t; Maximum number of transactions per block.; 200'000; 1'500
-    **plugin:catapult.plugins.accountlink**; ; ; ;
-    dummy; ; ; to trigger plugin load
-    **plugin:catapult.plugins.aggregate**; ; ; ;
-    maxTransactionsPerAggregate; uint32_t; Maximum number of transactions per aggregate.; 1'000; 1'000
-    maxCosignaturesPerAggregate; uint8_t; Maximum number of cosignatures per aggregate.; 15; 25
-    enableStrictCosignatureCheck; bool; Set to true if cosignatures must exactly match component signers. Set to false if cosignatures should be validated externally.; false; false
-    enableBondedAggregateSupport; bool; Set to true if bonded aggregates should be allowed. Set to false if bonded aggregates should be rejected.; true; true
-    maxBondedTransactionLifetime; utils::TimeSpan; Maximum lifetime a bonded transaction can have before it expires.; 48h; 48h
-    **plugin:catapult.plugins.lockhash**; ; ; ;
-    lockedFundsPerAggregate; Amount; Amount that has to be locked per aggregate in partial cache.; 10'000'000; 10'000'000
-    maxHashLockDuration; utils::BlockSpan; Maximum number of blocks for which a hash lock can exist.; 2d; 2d
-    **plugin:catapult.plugins.locksecret**; ; ;
-    maxSecretLockDuration; utils::BlockSpan; Maximum number of blocks for which a secret lock can exist.; 30d; 30d
-    minProofSize; uint16_t; Minimum size of a proof in bytes.; 1; 1
-    maxProofSize; uint16_t; Maximum size of a proof in bytes.; 1000; 1000
-    **plugin:catapult.plugins.metadata**; ; ; ;
-    maxValueSize; uint16_t; Maximum metadata value size.; 1024; 1024
-    **plugin:catapult.plugins.mosaic**; ; ; ;
-    maxMosaicsPerAccount; uint16_t; Maximum number of mosaics that an account can own.; 10'000; 1'000
-    maxMosaicDuration; utils::BlockSpan; Maximum mosaic duration.; 3650d; 3650d
-    maxMosaicDivisibility; uint8_t; Maximum mosaic divisibility.; 6; 6
-    mosaicRentalFeeSinkAddress; Address; Address of the mosaic rental fee sink account.; SDKDPA36TE53BO24FD4KA6OPGOUSEVOU3O5SIFI;
-    mosaicRentalFee; Amount; Mosaic rental fee.; 500; 500
-    **plugin:catapult.plugins.multisig**; ; ; ;
-    maxMultisigDepth; uint8_t; Maximum number of multisig levels.; 3; 3
-    maxCosignatoriesPerAccount; uint32_t; Maximum number of cosignatories per account.; 10; 25
-    maxCosignedAccountsPerAccount; uint32_t; Maximum number of accounts a single account can cosign.; 5; 25
-    **plugin:catapult.plugins.namespace**; ; ; ;
-    maxNameSize; uint8_t; Maximum namespace name size.; 64; 64
-    maxChildNamespaces; uint16_t; Maximum number of children for a root namespace.; 500; 256
-    maxNamespaceDepth; uint8_t; Maximum namespace depth.; 3; 3
-    minNamespaceDuration; utils::BlockSpan; Minimum namespace duration.; 1m; 30d
-    maxNamespaceDuration; utils::BlockSpan; Maximum namespace duration.; 365d; 365d
-    namespaceGracePeriodDuration; utils::BlockSpan; Grace period during which time only the previous owner can renew an expired namespace.; 2m; 30d
-    reservedRootNamespaceNames; unordered_set<string>; Reserved root namespaces that cannot be claimed.; xem, nem, user, account, org, com, biz, net, edu, mil, gov, info; symbol, symbl, xym, xem, nem, user, account, org, com, biz, net, edu, mil, gov, info
-    namespaceRentalFeeSinkAddress; Address; Address of the namespace rental fee sink account.; SDTZ23JBJZP3GTKKM2P6FYCMXS6RQYPB6R477TQ; 
-    rootNamespaceRentalFeePerBlock; Amount; Root namespace rental fee per block.; 1; 1
-    childNamespaceRentalFee; Amount; Child namespace rental fee.; 100; 100
-    **plugin:catapult.plugins.restrictionaccount**; ; ; ;
-    maxAccountRestrictionValues; uint16_t; Maximum number of account restriction values.; 512; 512
-    **plugin:catapult.plugins.restrictionmosaic**; ; ; ;
-    maxMosaicRestrictionValues; uint8_t; Maximum number of mosaic restriction values.; 20; 20
-    **plugin:catapult.plugins.transfer**; ; ; ;
-    maxMessageSize; uint16_t; Maximum transaction message size.; 1024; 1024
+***********************
+Inflation configuration
+***********************
 
-config-inflation.properties
-===========================
+.. raw:: html
+    :file: ../../_static/config-inflation.properties.html
 
-.. csv-table::
-    :header: "Property", "Type", "Description", "Default MIJIN_TEST"
-    :delim: ;
+.. |symbol-bootstrap| raw:: html
 
-    **inflation**; ; ;
-    starting-at-height-1; ; ; 100
-    starting-at-height-10000; ; ; 0
-
-.. |catapult-service-bootstrap| raw:: html
-
-   <a href="https://github.com/nemtech/catapult-service-bootstrap" target="_blank">Catapult Service Bootstrap</a>
+   <a href="https://github.com/nemtech/symbol-bootstrap" target="_blank">Symbol Bootstrap</a>

--- a/source/guides/network/configuring-node-properties.rst
+++ b/source/guides/network/configuring-node-properties.rst
@@ -9,140 +9,42 @@
 Configuring node properties
 ###########################
 
-Customize the node configurable parameters.
+|symbol-bootstrap| (read the :doc:`Using Symbol Bootstrap<using-symbol-bootstrap>` guide if you don't know what it is) accepts custom presets to customize the nodes to your needs.
 
-********
-Packages
-********
+The tables below list all the node-related properties that can be set. Put them in a YAML file and pass it to ``symbol-bootstrap config`` using the ``-c`` parameter.
 
-The instructions to configure the node vary depending on the package used to deploy the network.
+For example:
 
-Testnet Bootstrap
-=================
+.. code-block:: yaml
 
-After running a node for the first time, the file ``config-input.yaml`` will be generated in the folder ``symbol-testnet-bootstrap/identity``.
+    friendlyName: my-uber-node
+    dataDirectory: ./data
 
-To edit the node properties, follow the next steps:
-
-1. If the node service is running, run ``sudo docker-compose down`` under the same directory you executed the ``up`` command.
-
-2. Edit the properties file ``config-input.yaml`` with a text editor.
-
-3. Save and apply the changes with the command ``sudo docker-compose up --build --detach``.
-
-Service Bootstrap
-=================
-
-After running a network for the first time, the folder ``build/catapult-config`` contains all the properties files for the Peer and API nodes that compose the network.
-
-For example, if you want to edit the ``peer-node-0`` properties, follow the next steps:
-
-1. Stop all the services with the command ``./cmds/stop-all``.
-
-2. Open the properties file to edit under ``peer-node-0/userconfig/resources`` with a text editor.
-
-3. Save and apply the changes with the command ``./cmds/start-all -d``.
+For network-related properties, read the :doc:`Configuring network properties <configuring-network-properties>` guide.
 
 .. _node-properties:
 
-**********
-Properties
-**********
+******************
+User configuration
+******************
 
-Find below the list of configurable properties.
+.. raw:: html
+    :file: ../../_static/config-user.properties.html
 
-config-user.properties
-======================
+******************
+Node configuration
+******************
 
-.. csv-table::
-    :header: "Property", "Type", "Description", "Default"
-    :delim: ;
+.. raw:: html
+    :file: ../../_static/config-node.properties.html
 
-    **account**; ; ; 
-    enableDelegatedHarvestersAutoDetection; bool; Set to true if potential delegated harvesters should be automatically detected.; true
-    **storage**; ; ; 
-    dataDirectory; string; Data directory.; ../data
-    certificateDirectory; string; Certificate directory.; ../certificate
-    pluginsDirectory; string; Plugins directory.; .
+************************
+Harvesting Configuration
+************************
 
-config-node.properties
-======================
+.. raw:: html
+    :file: ../../_static/config-harvesting.properties.html
 
-.. csv-table::
-    :header: "Property", "Type", "Description", "Default"
-    :delim: ;
+.. |symbol-bootstrap| raw:: html
 
-    **node**; ; ;
-    port; unsigned short; Server port.; 7900
-    maxIncomingConnectionsPerIdentity; uint32_t; Maximum number of incoming connections per identity over primary port.; 3
-    enableAddressReuse; bool; Set to true if the server should reuse ports already in use.; false
-    enableSingleThreadPool; bool; Set to true if a single thread pool should be used, Set to false if multiple thread pools should be used.; false
-    enableCacheDatabaseStorage; bool; Set to true if cache data should be saved in a database.; true
-    enableAutoSyncCleanup; bool; Set to true if temporary sync files should be automatically cleaned up. *Note*: This should be Set to false if broker process is running.; true
-    enableTransactionSpamThrottling; bool; Set to true if transaction spam throttling should be enabled.; true
-    transactionSpamThrottlingMaxBoostFee; Amount; Maximum fee that will boost a transaction through the spam throttle when spam throttling is enabled.; 10'000'000
-    maxBlocksPerSyncAttempt; uint32_t; Maximum number of blocks per sync attempt.; 400
-    maxChainBytesPerSyncAttempt; utils::FileSize; Maximum chain bytes per sync attempt.; 100MB
-    shortLivedCacheTransactionDuration; utils::TimeSpan; Duration of a transaction in the short lived cache.; 10m
-    shortLivedCacheBlockDuration; utils::TimeSpan; Duration of a block in the short lived cache.; 100m
-    shortLivedCachePruneInterval; utils::TimeSpan; Time between short lived cache pruning.; 90s
-    shortLivedCacheMaxSize; uint32_t; Maximum size of a short lived cache.; 10'000'000
-    minFeeMultiplier; BlockFeeMultiplier; Minimum fee multiplier of transactions to propagate and include in blocks.; 0
-    transactionSelectionStrategy; model::TransactionSelectionStrategy; Transaction selection strategy used for syncing and harvesting unconfirmed transactions.; oldest
-    unconfirmedTransactionsCacheMaxResponseSize; utils::FileSize; Maximum size of an unconfirmed transactions response.; 20MB
-    unconfirmedTransactionsCacheMaxSize; uint32_t; Maximum size of the unconfirmed transactions cache.; 1'000'000
-    connectTimeout; utils::TimeSpan; Timeout for connecting to a peer.; 10s
-    syncTimeout; utils::TimeSpan; Timeout for syncing with a peer.; 60s
-    socketWorkingBufferSize; utils::FileSize; Initial socket working buffer size (socket reads will attempt to read buffers of roughly this size).; 512KB
-    socketWorkingBufferSensitivity; uint32_t; Socket working buffer sensitivity (lower values will cause memory to be more aggressively reclaimed). *Note*: Set to 0 will disable memory reclamation.; 100
-    maxPacketDataSize; utils::FileSize; Maximum packet data size.; 150MB
-    blockDisruptorSize; uint32_t; Size of the block disruptor circular buffer.; 4096
-    blockElementTraceInterval; uint32_t; Multiple of elements at which a block element should be traced through queue and completion.; 1
-    transactionDisruptorSize; uint32_t; Size of the transaction disruptor circular buffer.; 16384
-    transactionElementTraceInterval; uint32_t; Multiple of elements at which a transaction element should be traced through queue and completion.; 10
-    enableDispatcherAbortWhenFull; bool; Set to true if the process should terminate when any dispatcher is full.; true
-    enableDispatcherInputAuditing; bool; Set to true if all dispatcher inputs should be audited.; true
-    maxCacheDatabaseWriteBatchSize; utils::FileSize; Maximum cache database write batch size.; 5MB
-    maxTrackedNodes; uint32_t; Maximum number of nodes to track in memory.; 5'000
-    batchVerificationRandomSource; string; Source of random numbers used in batch verification.; /dev/urandom
-    trustedHosts; unordered_set<string>; Trusted hosts that are allowed to execute protected API calls on this node.;
-    localNetworks; unordered_set<string>; Networks that should be treated as local.; 127.0.0.1
-    **localnode**; ; ;
-    host; string; Node host (leave empty to auto-detect IP).;
-    friendlyName; string; Node friendly name (leave empty to use address).;
-    version; uint32_t; Node version.; 0
-    roles; ionet::NodeRoles; Node roles.; Peer
-    **outgoing_connections**; ; ;
-    maxConnections; uint16_t; Maximum number of active connections.; 10
-    maxConnectionAge; uint16_t; Maximum connection age.; 200
-    maxConnectionBanAge; uint16_t; Maximum connection ban age.; 20
-    numConsecutiveFailuresBeforeBanning; uint16_t; Number of consecutive connection failures before a connection is banned.; 3
-    **incoming_connections**; ; ;
-    maxConnections; uint16_t; Maximum number of active connections.; 512
-    maxConnectionAge; uint16_t; Maximum connection age.; 200
-    maxConnectionBanAge; uint16_t; Maximum connection ban age.; 20
-    numConsecutiveFailuresBeforeBanning; uint16_t; Number of consecutive connection failures before a connection is banned.; 3
-    backlogSize; uint16_t; Maximum size of the pending connections queue.; 512
-    **banning**; ; ;
-    defaultBanDuration; utils::TimeSpan; Default duration for banning.; 12h
-    maxBanDuration; utils::TimeSpan; Maximum duration for banning.; 72h
-    keepAliveDuration; utils::TimeSpan; Duration to keep account in container after the ban expired.; 48h
-    maxBannedNodes; uint32_t; Maximum number of banned nodes.; 5'000
-    numReadRateMonitoringBuckets; uint16_t; Number of read rate monitoring buckets (Set to 0 to disable read rate monitoring).; 4
-    readRateMonitoringBucketDuration; utils::TimeSpan; Duration of each read rate monitoring bucket.; 15s
-    maxReadRateMonitoringTotalSize; utils::FileSize; Maximum size allowed during full read rate monitoring period.; 100MB
-
-config-harvesting.properties
-============================
-
-.. csv-table::
-    :header: "Property", "Type", "Description", "Default"
-    :delim: ;
-
-    **harvesting**; ; ; 
-    harvesterSigningPrivateKey; string; Harvester signing private key.; 
-    harvesterVrfPrivateKey; string; Harvester vrf private key.; 
-    enableAutoHarvesting; bool; Set to true if auto harvesting is enabled.; false
-    maxUnlockedAccounts; uint32_t; Maximum number of unlocked accounts.; 5
-    delegatePrioritizationPolicy; harvesting::DelegatePrioritizationPolicy; Delegate harvester prioritization policy.; Importance
-    beneficiaryAddress; Address; Address of the account receiving part of the harvested fee.; 
+   <a href="https://github.com/nemtech/symbol-bootstrap" target="_blank">Symbol Bootstrap</a>

--- a/source/guides/network/configuring-node-properties.rst
+++ b/source/guides/network/configuring-node-properties.rst
@@ -9,18 +9,18 @@
 Configuring node properties
 ###########################
 
-|symbol-bootstrap| (read the :doc:`Using Symbol Bootstrap<using-symbol-bootstrap>` guide if you don't know what it is) accepts custom presets to customize the nodes to your needs.
+There is a large number of node-related settings that can be customized in |codename|.
 
-The tables below list all the node-related properties that can be set. Put them in a YAML file and pass it to ``symbol-bootstrap config`` using the ``-c`` parameter.
-
-For example:
+The easiest way to change them is by using |symbol-bootstrap|'s custom presets (read :doc:`Using Symbol Bootstrap<using-symbol-bootstrap>`): Put the settings in a YAML file and pass it to ``symbol-bootstrap config`` using the ``-c`` parameter. For example:
 
 .. code-block:: yaml
 
     friendlyName: my-uber-node
     dataDirectory: ./data
 
-For network-related properties, read the :doc:`Configuring network properties <configuring-network-properties>` guide.
+These settings can also be directly provided to |catapult-server| through ``.properties`` files. The header of each of the tables below indicates which file contains that table's properties.
+
+.. note:: For **network**-related properties, read the :doc:`Configuring network properties <configuring-network-properties>` guide.
 
 .. _node-properties:
 
@@ -48,3 +48,7 @@ Harvesting Configuration
 .. |symbol-bootstrap| raw:: html
 
    <a href="https://github.com/nemtech/symbol-bootstrap" target="_blank">Symbol Bootstrap</a>
+
+.. |catapult-server| raw:: html
+
+   <a href="https://github.com/nemtech/catapult-server" target="_blank">catapult-server</a>

--- a/source/guides/network/creating-a-private-test-net.rst
+++ b/source/guides/network/creating-a-private-test-net.rst
@@ -155,6 +155,12 @@ All nodes created by the ``bootstrap`` preset are voters by default. If you don'
 
 .. note:: Without ANY voting node no finalization can occur. By taking a look at ``localhost:3000/chain/info`` you will see you chain height grow but the ``latestFinalizedBlock``'s height will remain at zero.
 
+******************************
+Configuring network properties
+******************************
+
+Read the :doc:`Configuring network properties <configuring-network-properties>` guide for a list of network-related settings that can be customized.
+
 **********
 Next steps
 **********


### PR DESCRIPTION
The actual property tables are generated by
catapult-docs-cli using data from catapult-server and
testnet default values from symbol-bootstrap's reports.

Far more properties are available for publication.