### PR TITLE
fix recipient address for enrolling message

### DIFF
--- a/source/guides/network/supernode-enrollment.rst
+++ b/source/guides/network/supernode-enrollment.rst
@@ -153,14 +153,14 @@ The process requires **installing a monitoring agent** and **announcing a specia
 
    - Replace ``AGENT_URL`` with ``https://`` + the host where you are running the agent + ``:7880``. This URL must be **publicly accessible**. For example: ``https://my-symbol-node.com:7880``. IP addresses are also valid. Use the port number you specified in step 3 above if you didn't use the standard one.
 
-   Finally, the recipient address of this transaction is ``TDETDMT5S2ADAYGJXPATUHQUYVGSLSVJ6TLSXQQ``.
+   Finally, the recipient address of this transaction is ``TDL73SDUMPDK7EOF7H3O4F5WB5WHG2SX7XUSFZQ``.
 
    The transaction can be announced using :doc:`symbol-cli <../../cli>`:
 
    .. code-block:: symbol-cli
 
       symbol-cli transaction transfer --mode normal --sync \
-                 --recipient-address TDETDMT5S2ADAYGJXPATUHQUYVGSLSVJ6TLSXQQ \
+                 --recipient-address TDL73SDUMPDK7EOF7H3O4F5WB5WHG2SX7XUSFZQ \
                  --message "enrol NODE_PUBLIC_KEY AGENT_URL" \
                  --mosaics @symbol.xym::0
 

--- a/source/locale/ja/LC_MESSAGES/guides/network/supernode-enrollment.po
+++ b/source/locale/ja/LC_MESSAGES/guides/network/supernode-enrollment.po
@@ -264,7 +264,7 @@ msgstr ""
 #: ../../source/guides/network/supernode-enrollment.rst:183
 msgid ""
 "Finally, the recipient address of this transaction is "
-"``TDETDMT5S2ADAYGJXPATUHQUYVGSLSVJ6TLSXQQ``."
+"``TDL73SDUMPDK7EOF7H3O4F5WB5WHG2SX7XUSFZQ``."
 msgstr ""
 
 #: ../../source/guides/network/supernode-enrollment.rst:185


### PR DESCRIPTION
`CONTROLLER_PUBLIC_KEY=68B6A1D2F292E75F9BB8E9EDDA086A7C293A198C9968FF7528374075AAF4D983` in agent.propertis cannot be converted to `TDETDMT5S2ADAYGJXPATUHQUYVGSLSVJ6TLSXQQ`.

```
symbol-cli converter publickeyToAddress \
-p 68B6A1D2F292E75F9BB8E9EDDA086A7C293A198C9968FF7528374075AAF4D983 \
-n TEST_NET
TDL73S-DUMPDK-7EOF7H-3O4F5W-B5WHG2-SX7XUS-FZQ
```