### PR TITLE
Fix importance score recalculation period

### DIFF
--- a/source/guides/harvesting/activating-delegated-harvesting-manual.rst
+++ b/source/guides/harvesting/activating-delegated-harvesting-manual.rst
@@ -44,7 +44,7 @@ Prerequisites
 
 Before you can activate delegated harvesting, you need the following items:
 
-- A **Main account (M)** with at least **10,000** |networkcurrency| to be :ref:`eligible <account_eligibility>` and then some more to pay for transaction fees. This is the account that will receive the harvesting fees. Keep its private key secret at all times.
+- A **Main account (M)** with at least **10,000** |networkcurrency| to be :ref:`eligible <account_eligibility>` and then some more to pay for transaction fees. The account also has to have an :ref:`importance score <importance-calculation>` greater than zero (this score is calculated every 12h). This is the account that will receive the harvesting fees. Keep its private key secret at all times.
 
 - A **Remote account (R)** that will act as a proxy between **M** and the node. This account **must have never sent or received any transaction**, and it cannot be involved in any transaction while it is a delegated account.
 
@@ -164,6 +164,6 @@ Final words
 
 - **Accounts with higher importance are selected more often to perform harvesting**. Even if you successfully register as a delegated harvester with a node, you will not harvest any block (nor receive any fees) unless your :ref:`importance score <importance-calculation>` is high enough.
 
-- **Importance score calculation does not happen continuously**. By default, account importance scores are recalculated every 720 blocks (about every 6 hours). See the ``importanceGrouping`` property in the :ref:`Configuring network properties <config-network-properties>` guide.
+- **Importance score calculation does not happen continuously**. By default, account importance scores are recalculated every 1440 blocks (about every 12 hours). See the ``importanceGrouping`` property in the :ref:`Configuring network properties <config-network-properties>` guide.
 
 - Finally, as explained in :ref:`delegated-harvesting-verifying-activation` above, **announcing a Harvesting Delegation request does not guarantee being added as a delegated harvester**. Nodes are free to comply with the request or even to lie about its status.

--- a/source/guides/harvesting/activating-delegated-harvesting-wallet.rst
+++ b/source/guides/harvesting/activating-delegated-harvesting-wallet.rst
@@ -30,7 +30,11 @@ Before you can activate delegated harvesting using the Desktop Wallet, you need 
 
 - An up-to-date **Desktop Wallet**. Download the latest version from `the releases page <https://github.com/nemgrouplimited/symbol-desktop-wallet/releases>`__.
 
-- An **account** with at least **10,000** |networkcurrency| to be :ref:`eligible <account_eligibility>` and then some more to pay for transaction fees. This is the account that will receive the harvesting fees. Keep its secret key secret at all times!
+- An **account** that will receive the harvesting fees. It must have:
+
+  - At least **10,000** |networkcurrency| to be :ref:`eligible <account_eligibility>` and then some more to pay for transaction fees.
+
+  - An :ref:`importance score <importance-calculation>` greater than zero. Keep in mind that this score is calculated every 12h.
 
 *****
 Guide
@@ -154,6 +158,6 @@ Final words
 
 - **Accounts with higher importance are selected more often to perform harvesting**. Even if you successfully register as a delegated harvester with a node, you will not harvest any block (nor receive any fees) unless your :ref:`importance score <importance-calculation>` is high enough.
 
-- **Importance score calculation does not happen continuously**. By default, account importance scores are recalculated every 720 blocks (about every 6 hours). See the ``importanceGrouping`` property in the :ref:`Configuring network properties <config-network-properties>` guide.
+- **Importance score calculation does not happen continuously**. By default, account importance scores are recalculated every 1440 blocks (about every 12 hours). See the ``importanceGrouping`` property in the :ref:`Configuring network properties <config-network-properties>` guide.
 
 - Finally, as explained in the note above, **announcing a Harvesting Delegation request does not guarantee being added as a delegated harvester**. Nodes are free to comply with the request or even to lie about its status.

--- a/source/guides/harvesting/activating-remote-harvesting.rst
+++ b/source/guides/harvesting/activating-remote-harvesting.rst
@@ -122,4 +122,4 @@ The node should now be configured with remote harvesting. Keep these important p
 
 - **Accounts with higher importance are selected more often to perform harvesting**. Even if you successfully enable remote harvesting, you will not harvest any block (nor receive any fees) unless your main account's :ref:`importance score <importance-calculation>` is high enough.
 
-- **Importance score calculation does not happen continuously**. By default, account importance scores are recalculated every 720 blocks (about every 6 hours). See the ``importanceGrouping`` property in the :ref:`Configuring network properties <config-network-properties>` guide.
+- **Importance score calculation does not happen continuously**. By default, account importance scores are recalculated every 1440 blocks (about every 12 hours). See the ``importanceGrouping`` property in the :ref:`Configuring network properties <config-network-properties>` guide.


### PR DESCRIPTION
The score is the lowest of the previous TWO periods,
so when going up, you need to wait 12h, not 6h.
This is worth remarking, since this is the most usual
scenarios for new users.